### PR TITLE
Updated to allow Wire port selectable from setup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VL53L0X library for Arduino
 
-Version: 1.0.1<br>
-Release date: 2016 Dec 08<br>
+Version: 1.0.2<br>
+Release date: 2017 Jun 27<br>
 [![Build Status](https://travis-ci.org/pololu/vl53l0x-arduino.svg?branch=master)](https://travis-ci.org/pololu/vl53l0x-arduino)<br>
 [www.pololu.com](https://www.pololu.com/)
 
@@ -84,12 +84,12 @@ This library is intended to provide a quicker and easier way to get started usin
   Returns the current I&sup2;C address.
 
 * `bool begin(void)`<br>
-  Iniitializes the sensor to use Wire as the default port. 
+  Initializes the sensor to use Wire as the default port. 
 * `bool begin(&Wire1)`<br>
-  Iniitializes the sensor to use Wire1 as the default port or change Wire1 to Wire2, Wire3 etc.
+  Initializes the two wire interface to something other than the default Wire1 (for example, Wire2 or Wire3).
 
 * `bool init(bool io_2v8 = true)`<br>
-  Iniitializes and configures the sensor. If the optional argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. 
+  Initializes and configures the sensor. If the optional argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. 
 
 * `void writeReg(uint8_t reg, uint8_t value)`<br>
   Writes an 8-bit sensor register with the given value.
@@ -163,6 +163,6 @@ This library is intended to provide a quicker and easier way to get started usin
   Indicates whether a read timeout has occurred since the last call to `timeoutOccurred()`.
 
 ## Version history
-
+1.0.2 (2017 Jun 27): Fixed a typo in a register modification in `getSpadInfo()` (thanks @tridge).
 * 1.0.1 (2016 Dec 08): Fixed type error in `readReg32Bit()`.
 * 1.0.0 (2016 Aug 12): Original release.

--- a/README.md
+++ b/README.md
@@ -82,14 +82,18 @@ This library is intended to provide a quicker and easier way to get started usin
 
 * `uint8_t getAddress(void)`<br>
   Returns the current I&sup2;C address.
+  
+* `bool init()`<br>
+  Initializes and configures the sensor. If no arguments are specified uses defaults settings of io_2v8 = ture, and I2C set to use Wire. The return value is a boolean indicating whether the initialization completed successfully.
 
-* `bool begin(void)`<br>
-  Initializes the sensor to use Wire as the default port. 
-* `bool begin(&Wire1)`<br>
-  Initializes the two wire interface to something other than the default Wire1 (for example, Wire2 or Wire3).
+* `bool init(Wire)`<br>
+  Initializes the two wire interface to something other than the default Wire1 (for example, Wire2 or Wire3) and defaults to io_2v8 = true. The return value is a boolean indicating whether the initialization completed successfully.
 
-* `bool init(bool io_2v8 = true)`<br>
-  Initializes and configures the sensor. If the optional argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. 
+* `bool init(bool io_2v8)`<br>
+  If the argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. Defaults the two wire interface to Wire.
+
+* `bool init(bool io_2v8, Wire)`<br>
+  If the argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. Initializes the two wire interface to something other than the default Wire1 (for example, Wire2 or Wire3).
 
 * `void writeReg(uint8_t reg, uint8_t value)`<br>
   Writes an 8-bit sensor register with the given value.
@@ -163,6 +167,7 @@ This library is intended to provide a quicker and easier way to get started usin
   Indicates whether a read timeout has occurred since the last call to `timeoutOccurred()`.
 
 ## Version history
-1.0.2 (2017 Jun 27): Fixed a typo in a register modification in `getSpadInfo()` (thanks @tridge).
+
+* 1.0.2 (2017 Jun 27): Fixed a typo in a register modification in `getSpadInfo()` (thanks @tridge).
 * 1.0.1 (2016 Dec 08): Fixed type error in `readReg32Bit()`.
 * 1.0.0 (2016 Aug 12): Original release.

--- a/README.md
+++ b/README.md
@@ -84,10 +84,10 @@ This library is intended to provide a quicker and easier way to get started usin
   Returns the current I&sup2;C address.
   
 * `bool init()`<br>
-  Initializes and configures the sensor. If no arguments are specified uses defaults settings of io_2v8 = ture, and I2C set to use Wire. The return value is a boolean indicating whether the initialization completed successfully.
+  Initializes and configures the sensor. If no arguments are specified uses defaults settings of io_2v8 = true, and I2C set to use Wire. The return value is a boolean indicating whether the initialization completed successfully.
 
 * `bool init(Wire)`<br>
-  Initializes the two wire interface to something other than the default Wire1 (for example, Wire2 or Wire3) and defaults to io_2v8 = true. The return value is a boolean indicating whether the initialization completed successfully.
+  Initializes the two wire interface to something other than the default Wire (for example, Wire1, Wire2 or Wire3) and defaults to io_2v8 = true. The return value is a boolean indicating whether the initialization completed successfully.
 
 * `bool init(bool io_2v8)`<br>
   If the argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. Defaults the two wire interface to Wire.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # VL53L0X library for Arduino
 
-Version: 1.0.2<br>
-Release date: 2017 Jun 27<br>
+Version: 1.0.1<br>
+Release date: 2016 Dec 08<br>
 [![Build Status](https://travis-ci.org/pololu/vl53l0x-arduino.svg?branch=master)](https://travis-ci.org/pololu/vl53l0x-arduino)<br>
 [www.pololu.com](https://www.pololu.com/)
 
@@ -83,6 +83,11 @@ This library is intended to provide a quicker and easier way to get started usin
 * `uint8_t getAddress(void)`<br>
   Returns the current I&sup2;C address.
 
+* `bool begin(void)`<br>
+  Iniitializes the sensor to use Wire as the default port. 
+* `bool begin(&Wire1)`<br>
+  Iniitializes the sensor to use Wire1 as the default port or change Wire1 to Wire2, Wire3 etc.
+
 * `bool init(bool io_2v8 = true)`<br>
   Iniitializes and configures the sensor. If the optional argument `io_2v8` is true (the default if not specified), the sensor is configured for 2V8 mode (2.8 V I/O); if false, the sensor is left in 1V8 mode. The return value is a boolean indicating whether the initialization completed successfully. 
 
@@ -159,6 +164,5 @@ This library is intended to provide a quicker and easier way to get started usin
 
 ## Version history
 
-* 1.0.2 (2017 Jun 27): Fixed a typo in a register modification in `getSpadInfo()` (thanks @tridge).
 * 1.0.1 (2016 Dec 08): Fixed type error in `readReg32Bit()`.
 * 1.0.0 (2016 Aug 12): Original release.

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -41,16 +41,32 @@ VL53L0X::VL53L0X(void)
 {
 }
 
-void VL53L0X::begin()
+bool VL53L0X::init(void)
 {
   wire = &Wire;
   wire -> begin();
+  return begin(true);
 }
 
-void VL53L0X::begin(TwoWire &theWire)
+bool VL53L0X::init(TwoWire &theWire)
 {
   wire = &theWire;
   wire -> begin();
+  return begin(true);
+}
+
+bool VL53L0X::init(bool io_2v8)
+{
+  wire = &Wire;
+  wire -> begin();
+  return begin(io_2v8);
+}
+
+bool VL53L0X::init(bool io_2v8, TwoWire &theWire)
+{
+  wire = &theWire;
+  wire -> begin();
+  return begin(io_2v8);
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
@@ -69,7 +85,7 @@ void VL53L0X::setAddress(uint8_t new_addr)
 // enough unless a cover glass is added.
 // If io_2v8 (optional) is true or not given, the sensor is configured for 2V8
 // mode.
-bool VL53L0X::init(bool io_2v8)
+bool VL53L0X::begin(bool io_2v8)
 {
   // VL53L0X_DataInit() begin
 

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -45,13 +45,14 @@ VL53L0X::VL53L0X(void)
 void VL53L0X::begin()
 {
 	wire = &Wire;
+	wire -> begin();
 
 }
 
 void VL53L0X::begin(TwoWire *theWire)
 {
 	wire = theWire;
-	
+	wire -> begin();
 }
 
 // Public Methods //////////////////////////////////////////////////////////////

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -6,6 +6,7 @@
 #include <VL53L0X.h>
 #include <Wire.h>
 
+
 // Defines /////////////////////////////////////////////////////////////////////
 
 // The Arduino two-wire interface uses a 7-bit number for the address,
@@ -39,6 +40,18 @@ VL53L0X::VL53L0X(void)
   , io_timeout(0) // no timeout
   , did_timeout(false)
 {
+}
+
+void VL53L0X::begin()
+{
+	wire = &Wire;
+
+}
+
+void VL53L0X::begin(TwoWire *theWire)
+{
+	wire = theWire;
+	
 }
 
 // Public Methods //////////////////////////////////////////////////////////////
@@ -281,32 +294,32 @@ bool VL53L0X::init(bool io_2v8)
 // Write an 8-bit register
 void VL53L0X::writeReg(uint8_t reg, uint8_t value)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  Wire.write(value);
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  wire -> write(value);
+  last_status = wire -> endTransmission();
 }
 
 // Write a 16-bit register
 void VL53L0X::writeReg16Bit(uint8_t reg, uint16_t value)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  Wire.write((value >> 8) & 0xFF); // value high byte
-  Wire.write( value       & 0xFF); // value low byte
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  wire -> write((value >> 8) & 0xFF); // value high byte
+  wire -> write( value       & 0xFF); // value low byte
+  last_status = wire -> endTransmission();
 }
 
 // Write a 32-bit register
 void VL53L0X::writeReg32Bit(uint8_t reg, uint32_t value)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  Wire.write((value >> 24) & 0xFF); // value highest byte
-  Wire.write((value >> 16) & 0xFF);
-  Wire.write((value >>  8) & 0xFF);
-  Wire.write( value        & 0xFF); // value lowest byte
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  wire -> write((value >> 24) & 0xFF); // value highest byte
+  wire -> write((value >> 16) & 0xFF);
+  wire -> write((value >>  8) & 0xFF);
+  wire -> write( value        & 0xFF); // value lowest byte
+  last_status = wire -> endTransmission();
 }
 
 // Read an 8-bit register
@@ -314,12 +327,12 @@ uint8_t VL53L0X::readReg(uint8_t reg)
 {
   uint8_t value;
 
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  last_status = wire -> endTransmission();
 
-  Wire.requestFrom(address, (uint8_t)1);
-  value = Wire.read();
+  wire -> requestFrom(address, (uint8_t)1);
+  value = wire -> read();
 
   return value;
 }
@@ -329,13 +342,13 @@ uint16_t VL53L0X::readReg16Bit(uint8_t reg)
 {
   uint16_t value;
 
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  last_status = wire -> endTransmission();
 
-  Wire.requestFrom(address, (uint8_t)2);
-  value  = (uint16_t)Wire.read() << 8; // value high byte
-  value |=           Wire.read();      // value low byte
+  wire -> requestFrom(address, (uint8_t)2);
+  value  = (uint16_t) wire -> read() << 8; // value high byte
+  value |=            wire -> read();      // value low byte
 
   return value;
 }
@@ -345,15 +358,15 @@ uint32_t VL53L0X::readReg32Bit(uint8_t reg)
 {
   uint32_t value;
 
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  last_status = wire -> endTransmission();
 
-  Wire.requestFrom(address, (uint8_t)4);
-  value  = (uint32_t)Wire.read() << 24; // value highest byte
-  value |= (uint32_t)Wire.read() << 16;
-  value |= (uint16_t)Wire.read() <<  8;
-  value |=           Wire.read();       // value lowest byte
+  wire -> requestFrom(address, (uint8_t)4);
+  value  = (uint32_t)wire -> read() << 24; // value highest byte
+  value |= (uint32_t)wire -> read() << 16;
+  value |= (uint16_t)wire -> read() <<  8;
+  value |=           wire -> read();       // value lowest byte
 
   return value;
 }
@@ -362,30 +375,30 @@ uint32_t VL53L0X::readReg32Bit(uint8_t reg)
 // starting at the given register
 void VL53L0X::writeMulti(uint8_t reg, uint8_t const * src, uint8_t count)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
+  wire -> beginTransmission(address);
+  wire -> write(reg);
 
   while (count-- > 0)
   {
-    Wire.write(*(src++));
+    wire -> write(*(src++));
   }
 
-  last_status = Wire.endTransmission();
+  last_status = wire -> endTransmission();
 }
 
 // Read an arbitrary number of bytes from the sensor, starting at the given
 // register, into the given array
 void VL53L0X::readMulti(uint8_t reg, uint8_t * dst, uint8_t count)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire -> beginTransmission(address);
+  wire -> write(reg);
+  last_status = wire -> endTransmission();
 
-  Wire.requestFrom(address, count);
+  wire -> requestFrom(address, count);
 
   while (count-- > 0)
   {
-    *(dst++) = Wire.read();
+    *(dst++) = wire -> read();
   }
 }
 

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -6,7 +6,6 @@
 #include <VL53L0X.h>
 #include <Wire.h>
 
-
 // Defines /////////////////////////////////////////////////////////////////////
 
 // The Arduino two-wire interface uses a 7-bit number for the address,
@@ -44,15 +43,14 @@ VL53L0X::VL53L0X(void)
 
 void VL53L0X::begin()
 {
-	wire = &Wire;
-	wire -> begin();
-
+  wire = &Wire;
+  wire -> begin();
 }
 
-void VL53L0X::begin(TwoWire *theWire)
+void VL53L0X::begin(TwoWire &theWire)
 {
-	wire = theWire;
-	wire -> begin();
+  wire = &theWire;
+  wire -> begin();
 }
 
 // Public Methods //////////////////////////////////////////////////////////////

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -102,8 +102,8 @@ class VL53L0X
 	
     bool init(void);
     bool init(TwoWire &theWire);
-	bool init(bool io_2v8);
-	bool init(bool io_2v8, TwoWire &theWire);
+    bool init(bool io_2v8);
+    bool init(bool io_2v8, TwoWire &theWire);
 
     void setAddress(uint8_t new_addr);
     inline uint8_t getAddress(void) { return address; }

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -100,8 +100,8 @@ class VL53L0X
 
     VL53L0X(void);
 	
-	void begin();
-	void begin(TwoWire *theWire);
+    void begin();
+    void begin(TwoWire &theWire);
 
     void setAddress(uint8_t new_addr);
     inline uint8_t getAddress(void) { return address; }
@@ -137,8 +137,6 @@ class VL53L0X
     bool timeoutOccurred(void);
 
   private:
-	TwoWire *wire;
-  
     // TCC: Target CentreCheck
     // MSRC: Minimum Signal Rate Check
     // DSS: Dynamic Spad Selection
@@ -156,6 +154,7 @@ class VL53L0X
       uint32_t msrc_dss_tcc_us,    pre_range_us,    final_range_us;
     };
 
+    TwoWire *wire;
     uint8_t address;
     uint16_t io_timeout;
     bool did_timeout;

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -100,13 +100,15 @@ class VL53L0X
 
     VL53L0X(void);
 	
-    void begin();
-    void begin(TwoWire &theWire);
+    bool init(void);
+    bool init(TwoWire &theWire);
+	bool init(bool io_2v8);
+	bool init(bool io_2v8, TwoWire &theWire);
 
     void setAddress(uint8_t new_addr);
     inline uint8_t getAddress(void) { return address; }
 
-    bool init(bool io_2v8 = true);
+    bool begin(bool io_2v8);
 
     void writeReg(uint8_t reg, uint8_t value);
     void writeReg16Bit(uint8_t reg, uint16_t value);

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -2,6 +2,8 @@
 #define VL53L0X_h
 
 #include <Arduino.h>
+#include "HardwareSerial.h"
+#include <Wire.h>
 
 class VL53L0X
 {
@@ -97,6 +99,9 @@ class VL53L0X
     uint8_t last_status; // status of last I2C transmission
 
     VL53L0X(void);
+	
+	void begin();
+	void begin(TwoWire *theWire);
 
     void setAddress(uint8_t new_addr);
     inline uint8_t getAddress(void) { return address; }
@@ -132,6 +137,8 @@ class VL53L0X
     bool timeoutOccurred(void);
 
   private:
+	TwoWire *wire;
+  
     // TCC: Target CentreCheck
     // MSRC: Minimum Signal Rate Check
     // DSS: Dynamic Spad Selection

--- a/examples/Continuous/Continuous.ino
+++ b/examples/Continuous/Continuous.ino
@@ -14,6 +14,7 @@ void setup()
   Serial.begin(9600);
   Wire.begin();
 
+  sensor.begin();   // to change wire port use sensor.begin(&Wire1) for example
   sensor.init();
   sensor.setTimeout(500);
 

--- a/examples/Continuous/Continuous.ino
+++ b/examples/Continuous/Continuous.ino
@@ -12,7 +12,6 @@ VL53L0X sensor;
 void setup()
 {
   Serial.begin(9600);
-  Wire.begin();
 
   sensor.begin();   // to change wire port use sensor.begin(&Wire1) for example
   sensor.init();

--- a/examples/Continuous/Continuous.ino
+++ b/examples/Continuous/Continuous.ino
@@ -13,8 +13,7 @@ void setup()
 {
   Serial.begin(9600);
 
-  sensor.begin();   // to change wire port use sensor.begin(&Wire1) for example
-  sensor.init();
+  sensor.init();   // to change wire port use sensor.begin(Wire1) for example
   sensor.setTimeout(500);
 
   // Start continuous back-to-back mode (take readings as

--- a/examples/Single/Single.ino
+++ b/examples/Single/Single.ino
@@ -35,8 +35,7 @@ void setup()
 {
   Serial.begin(9600);
 
-
-  sensor.begin();   // to change wire port use sensor.begin(&Wire1) for example
+  sensor.begin();   // to change wire port use sensor.begin(Wire1) for example
   sensor.init();
   sensor.setTimeout(500);
 

--- a/examples/Single/Single.ino
+++ b/examples/Single/Single.ino
@@ -35,8 +35,7 @@ void setup()
 {
   Serial.begin(9600);
 
-  sensor.begin();   // to change wire port use sensor.begin(Wire1) for example
-  sensor.init();
+  sensor.init(); // to change wire port use sensor.begin(Wire1) for example
   sensor.setTimeout(500);
 
 #if defined LONG_RANGE

--- a/examples/Single/Single.ino
+++ b/examples/Single/Single.ino
@@ -36,6 +36,7 @@ void setup()
   Serial.begin(9600);
   Wire.begin();
 
+  sensor.begin();   // to change wire port use sensor.begin(&Wire1) for example
   sensor.init();
   sensor.setTimeout(500);
 

--- a/examples/Single/Single.ino
+++ b/examples/Single/Single.ino
@@ -34,7 +34,7 @@ VL53L0X sensor;
 void setup()
 {
   Serial.begin(9600);
-  Wire.begin();
+
 
   sensor.begin();   // to change wire port use sensor.begin(&Wire1) for example
   sensor.init();


### PR DESCRIPTION
I modified the library to make the Wire port selectable in the setup. Basically, you need to add one line in the examples (which I did):

sensor.begin(); - to use Wire as the default
sensor.begin(&Wire1); - to use Wire1 as the default.

I also fixed the issues from the previous pull request. I tested this on a Teensy 3.5 so you might want to test on a couple of other boards?

Thanks
Mike

