### PR TITLE
Add constructor for sensor with already changed slave device address

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ This library is intended to provide a quicker and easier way to get started usin
 * `VL53L0X(void)`<br>
   Constructor.
 
+* `VL53L0X(const uint8_t new_addr)`<br>
+  Constructor for sensor with already changed I&sup2;C slave device address of the VL53L0X to the given value (7-bit).
+
 * `void setAddress(uint8_t new_addr)`<br>
   Changes the I&sup2;C slave device address of the VL53L0X to the given value (7-bit).
 

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -41,6 +41,13 @@ VL53L0X::VL53L0X(void)
 {
 }
 
+VL53L0X::VL53L0X(const uint8_t new_addr)
+  : address(new_addr)
+  , io_timeout(0) // no timeout
+  , did_timeout(false)
+{
+}
+
 // Public Methods //////////////////////////////////////////////////////////////
 
 void VL53L0X::setAddress(uint8_t new_addr)

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -97,6 +97,7 @@ class VL53L0X
     uint8_t last_status; // status of last I2C transmission
 
     VL53L0X(void);
+    VL53L0X(const uint8_t new_addr);
 
     void setAddress(uint8_t new_addr);
     inline uint8_t getAddress(void) { return address; }


### PR DESCRIPTION
On using multiple VL53L0X devices as following, the first device's slave
address was changed to new one 0x54 if I called setAddress() for the
second device's instance. This commit fixes this issue.

1. 0x52 (default)
2. 0x54