### PR TITLE
Fix rare, intermittent, endless loop in timeouts

### DIFF
--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -16,7 +16,7 @@
 #define startTimeout() (timeout_start_ms = millis())
 
 // Check if timeout is enabled (set to nonzero value) and has expired
-#define checkTimeoutExpired() (io_timeout > 0 && ((uint16_t)millis() - timeout_start_ms) > io_timeout)
+#define checkTimeoutExpired() (io_timeout > 0 && (millis() - timeout_start_ms) > io_timeout)
 
 // Decode VCSEL (vertical cavity surface emitting laser) pulse period in PCLKs
 // from register value

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -152,7 +152,7 @@ class VL53L0X
     uint8_t address;
     uint16_t io_timeout;
     bool did_timeout;
-    uint16_t timeout_start_ms;
+    uint32_t timeout_start_ms;
 
     uint8_t stop_variable; // read by init and used when starting measurement; is StopVariable field of VL53L0X_DevData_t structure in API
     uint32_t measurement_timing_budget_us;


### PR DESCRIPTION
Don't reduce millis() and timeout_start_ms to 16 bit as this causes
wrapping every 65 seconds which can lead to endless loops from
checkTimeoutExpired() if the sensor times out when the 16 bit millis() is
within io_timeout of wrapping.