### PR TITLE
Functionality as a submodule

### DIFF
--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -3,7 +3,7 @@
 // or paraphrased from the API source code, API user manual (UM2039), and the
 // VL53L0X datasheet.
 
-#include <VL53L0X.h>
+#include "VL53L0X.h"
 #include <Wire.h>
 
 // Defines /////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
When using your library as a git submodule (library not included inside Arduino libraries folder), Arduino IDE compiler throws an error `VL53L0X.h: No such file or directory`. This is caused by the way the compiler looks for `VL53L0X.h` file when included by `#include <VL53L0X.h>`. This error can be solved by including the file with `#include "VL53L0X.h"` instead. This makes it work as it should because both files are in the same directory, and it does not compromise any other library functionalities. Please consider this pull request as this change is necessary for your library to be used as a submodule. Thank you.