### PR TITLE
Optionally support other Wire objects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ This library is intended to provide a quicker and easier way to get started usin
 * `uint8_t last_status`<br>
   The status of the last I&sup2;C write transmission. See the [`Wire.endTransmission()` documentation](http://arduino.cc/en/Reference/WireEndTransmission) for return values.
 
-* `VL53L0X(void)`<br>
-  Constructor.
+* `VL53L0X(TwoWire *theWire = &Wire)`<br>
+  Constructor. Optionally for systems with mutliple Wire objects, you can choose which Wire object this object should use.
 
 * `void setAddress(uint8_t new_addr)`<br>
   Changes the I&sup2;C slave device address of the VL53L0X to the given value (7-bit).

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -34,8 +34,9 @@
 
 // Constructors ////////////////////////////////////////////////////////////////
 
-VL53L0X::VL53L0X(void)
-  : address(ADDRESS_DEFAULT)
+VL53L0X::VL53L0X(TwoWire *theWire)
+  : wire_ptr(theWire)
+  , address(ADDRESS_DEFAULT)
   , io_timeout(0) // no timeout
   , did_timeout(false)
 {
@@ -284,32 +285,32 @@ bool VL53L0X::init(bool io_2v8)
 // Write an 8-bit register
 void VL53L0X::writeReg(uint8_t reg, uint8_t value)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  Wire.write(value);
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  wire_ptr->write(value);
+  last_status = wire_ptr->endTransmission();
 }
 
 // Write a 16-bit register
 void VL53L0X::writeReg16Bit(uint8_t reg, uint16_t value)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  Wire.write((value >> 8) & 0xFF); // value high byte
-  Wire.write( value       & 0xFF); // value low byte
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  wire_ptr->write((value >> 8) & 0xFF); // value high byte
+  wire_ptr->write( value       & 0xFF); // value low byte
+  last_status = wire_ptr->endTransmission();
 }
 
 // Write a 32-bit register
 void VL53L0X::writeReg32Bit(uint8_t reg, uint32_t value)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  Wire.write((value >> 24) & 0xFF); // value highest byte
-  Wire.write((value >> 16) & 0xFF);
-  Wire.write((value >>  8) & 0xFF);
-  Wire.write( value        & 0xFF); // value lowest byte
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  wire_ptr->write((value >> 24) & 0xFF); // value highest byte
+  wire_ptr->write((value >> 16) & 0xFF);
+  wire_ptr->write((value >>  8) & 0xFF);
+  wire_ptr->write( value        & 0xFF); // value lowest byte
+  last_status = wire_ptr->endTransmission();
 }
 
 // Read an 8-bit register
@@ -317,12 +318,12 @@ uint8_t VL53L0X::readReg(uint8_t reg)
 {
   uint8_t value;
 
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  last_status = wire_ptr->endTransmission();
 
-  Wire.requestFrom(address, (uint8_t)1);
-  value = Wire.read();
+  wire_ptr->requestFrom(address, (uint8_t)1);
+  value = wire_ptr->read();
 
   return value;
 }
@@ -332,13 +333,13 @@ uint16_t VL53L0X::readReg16Bit(uint8_t reg)
 {
   uint16_t value;
 
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  last_status = wire_ptr->endTransmission();
 
-  Wire.requestFrom(address, (uint8_t)2);
-  value  = (uint16_t)Wire.read() << 8; // value high byte
-  value |=           Wire.read();      // value low byte
+  wire_ptr->requestFrom(address, (uint8_t)2);
+  value  = (uint16_t)wire_ptr->read() << 8; // value high byte
+  value |=           wire_ptr->read();      // value low byte
 
   return value;
 }
@@ -348,15 +349,15 @@ uint32_t VL53L0X::readReg32Bit(uint8_t reg)
 {
   uint32_t value;
 
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  last_status = wire_ptr->endTransmission();
 
-  Wire.requestFrom(address, (uint8_t)4);
-  value  = (uint32_t)Wire.read() << 24; // value highest byte
-  value |= (uint32_t)Wire.read() << 16;
-  value |= (uint16_t)Wire.read() <<  8;
-  value |=           Wire.read();       // value lowest byte
+  wire_ptr->requestFrom(address, (uint8_t)4);
+  value  = (uint32_t)wire_ptr->read() << 24; // value highest byte
+  value |= (uint32_t)wire_ptr->read() << 16;
+  value |= (uint16_t)wire_ptr->read() <<  8;
+  value |=           wire_ptr->read();       // value lowest byte
 
   return value;
 }
@@ -365,30 +366,30 @@ uint32_t VL53L0X::readReg32Bit(uint8_t reg)
 // starting at the given register
 void VL53L0X::writeMulti(uint8_t reg, uint8_t const * src, uint8_t count)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
 
   while (count-- > 0)
   {
-    Wire.write(*(src++));
+    wire_ptr->write(*(src++));
   }
 
-  last_status = Wire.endTransmission();
+  last_status = wire_ptr->endTransmission();
 }
 
 // Read an arbitrary number of bytes from the sensor, starting at the given
 // register, into the given array
 void VL53L0X::readMulti(uint8_t reg, uint8_t * dst, uint8_t count)
 {
-  Wire.beginTransmission(address);
-  Wire.write(reg);
-  last_status = Wire.endTransmission();
+  wire_ptr->beginTransmission(address);
+  wire_ptr->write(reg);
+  last_status = wire_ptr->endTransmission();
 
-  Wire.requestFrom(address, count);
+  wire_ptr->requestFrom(address, count);
 
   while (count-- > 0)
   {
-    *(dst++) = Wire.read();
+    *(dst++) = wire_ptr->read();
   }
 }
 

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -2,6 +2,7 @@
 #define VL53L0X_h
 
 #include <Arduino.h>
+#include <Wire.h>
 
 class VL53L0X
 {
@@ -96,7 +97,7 @@ class VL53L0X
 
     uint8_t last_status; // status of last I2C transmission
 
-    VL53L0X(void);
+    VL53L0X(TwoWire *theWire = &Wire);
 
     void setAddress(uint8_t new_addr);
     inline uint8_t getAddress(void) { return address; }
@@ -149,6 +150,7 @@ class VL53L0X
       uint32_t msrc_dss_tcc_us,    pre_range_us,    final_range_us;
     };
 
+    TwoWire *wire_ptr;
     uint8_t address;
     uint16_t io_timeout;
     bool did_timeout;

--- a/examples/Continuous/Continuous.ino
+++ b/examples/Continuous/Continuous.ino
@@ -13,7 +13,6 @@ void setup()
 {
   Serial.begin(9600);
   Wire.begin();
-
   sensor.setTimeout(500);
   if (!sensor.init())
   {


### PR DESCRIPTION
Many processors, now days have more than one hardware I2C on them.  Sometimes it is convenient to use a different I2C object like Wire1 or Wire2 instead of the default Wire object.

This change allows you to pass in a pointer to the desired I2C(Wire) object on the constructor. which defaults to Wire.

This change requires the main header file to include the wire.h header file.