### PR TITLE
Fixed wrong timing budget

### DIFF
--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -30,7 +30,7 @@
 // Calculate macro period in *nanoseconds* from VCSEL period in PCLKs
 // based on VL53L0X_calc_macro_period_ps()
 // PLL_period_ps = 1655; macro_period_vclks = 2304
-#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304 * (vcsel_period_pclks) * 1655) + 500) / 100)
+#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304 * (vcsel_period_pclks) * 1655) + 50) / 100)
 
 // Constructors ////////////////////////////////////////////////////////////////
 

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -30,7 +30,7 @@
 // Calculate macro period in *nanoseconds* from VCSEL period in PCLKs
 // based on VL53L0X_calc_macro_period_ps()
 // PLL_period_ps = 1655; macro_period_vclks = 2304
-#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304 * (vcsel_period_pclks) * 1655) + 500) / 1000)
+#define calcMacroPeriod(vcsel_period_pclks) ((((uint32_t)2304 * (vcsel_period_pclks) * 1655) + 500) / 100)
 
 // Constructors ////////////////////////////////////////////////////////////////
 
@@ -1006,7 +1006,7 @@ uint32_t VL53L0X::timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint
 {
   uint32_t macro_period_ns = calcMacroPeriod(vcsel_period_pclks);
 
-  return ((timeout_period_mclks * macro_period_ns) + 500) / 1000;
+  return ((timeout_period_mclks * macro_period_ns) + (macro_period_ns / 2)) / 1000;
 }
 
 // Convert sequence step timeout from microseconds to MCLKs with given VCSEL period in PCLKs


### PR DESCRIPTION
This PR fixes an error in calculation of  VCSEL period.
Now, if a measurement budget of e.g. 20ms is set, the measurement actually takes (around) 20ms, not 200ms.

Image represents the I2C communication in the top two rows and the interrupt line in the third. Notice the 22ms pulse width instead of 199ms.
![image](https://user-images.githubusercontent.com/7480344/96933456-c406fa00-14c0-11eb-8c6c-27f543376c86.png)