### PR TITLE
Keep i2c error as bit flag which TwoWire::endTransmission() returns

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ This library is intended to provide a quicker and easier way to get started usin
 * `bool timeoutOccurred()`<br>
   Indicates whether a read timeout has occurred since the last call to `timeoutOccurred()`.
 
+* `uint8_t getWireErrorBits(void)`<br>
+  Indicates what I&sup2;C transmission errors have occurred since the last call to VL53L0X API. Returns 0 if `last_status` was success, but returns value whose bit is set corresponding to error status written on [`Wire.endTransmission()` documentation](http://arduino.cc/en/Reference/WireEndTransmission).
+
 ## Version history
 
 * 1.3.0 (2020 Sep 24): Added support for alternative I&sup2;C buses (thanks KurtE).

--- a/VL53L0X.cpp
+++ b/VL53L0X.cpp
@@ -39,6 +39,7 @@ VL53L0X::VL53L0X()
   , address(ADDRESS_DEFAULT)
   , io_timeout(0) // no timeout
   , did_timeout(false)
+  , wire_error(0)
 {
 }
 
@@ -289,6 +290,7 @@ void VL53L0X::writeReg(uint8_t reg, uint8_t value)
   bus->write(reg);
   bus->write(value);
   last_status = bus->endTransmission();
+  setWireErrorBit();
 }
 
 // Write a 16-bit register
@@ -299,6 +301,7 @@ void VL53L0X::writeReg16Bit(uint8_t reg, uint16_t value)
   bus->write((value >> 8) & 0xFF); // value high byte
   bus->write( value       & 0xFF); // value low byte
   last_status = bus->endTransmission();
+  setWireErrorBit();
 }
 
 // Write a 32-bit register
@@ -311,6 +314,7 @@ void VL53L0X::writeReg32Bit(uint8_t reg, uint32_t value)
   bus->write((value >>  8) & 0xFF);
   bus->write( value        & 0xFF); // value lowest byte
   last_status = bus->endTransmission();
+  setWireErrorBit();
 }
 
 // Read an 8-bit register
@@ -321,6 +325,7 @@ uint8_t VL53L0X::readReg(uint8_t reg)
   bus->beginTransmission(address);
   bus->write(reg);
   last_status = bus->endTransmission();
+  setWireErrorBit();
 
   bus->requestFrom(address, (uint8_t)1);
   value = bus->read();
@@ -336,6 +341,7 @@ uint16_t VL53L0X::readReg16Bit(uint8_t reg)
   bus->beginTransmission(address);
   bus->write(reg);
   last_status = bus->endTransmission();
+  setWireErrorBit();
 
   bus->requestFrom(address, (uint8_t)2);
   value  = (uint16_t)bus->read() << 8; // value high byte
@@ -352,6 +358,7 @@ uint32_t VL53L0X::readReg32Bit(uint8_t reg)
   bus->beginTransmission(address);
   bus->write(reg);
   last_status = bus->endTransmission();
+  setWireErrorBit();
 
   bus->requestFrom(address, (uint8_t)4);
   value  = (uint32_t)bus->read() << 24; // value highest byte
@@ -375,6 +382,7 @@ void VL53L0X::writeMulti(uint8_t reg, uint8_t const * src, uint8_t count)
   }
 
   last_status = bus->endTransmission();
+  setWireErrorBit();
 }
 
 // Read an arbitrary number of bytes from the sensor, starting at the given
@@ -384,6 +392,7 @@ void VL53L0X::readMulti(uint8_t reg, uint8_t * dst, uint8_t count)
   bus->beginTransmission(address);
   bus->write(reg);
   last_status = bus->endTransmission();
+  setWireErrorBit();
 
   bus->requestFrom(address, count);
 
@@ -870,6 +879,15 @@ bool VL53L0X::timeoutOccurred()
 {
   bool tmp = did_timeout;
   did_timeout = false;
+  return tmp;
+}
+
+// Did I2C transmission error occur in one of the read/write functions since
+// the last call to getWireErrorBits()?
+uint8_t VL53L0X::getWireErrorBits()
+{
+  const uint8_t tmp = wire_error;
+  wire_error = 0;
   return tmp;
 }
 

--- a/VL53L0X.h
+++ b/VL53L0X.h
@@ -134,6 +134,7 @@ class VL53L0X
     inline void setTimeout(uint16_t timeout) { io_timeout = timeout; }
     inline uint16_t getTimeout() { return io_timeout; }
     bool timeoutOccurred();
+    uint8_t getWireErrorBits(void);
 
   private:
     // TCC: Target CentreCheck
@@ -158,6 +159,7 @@ class VL53L0X
     uint16_t io_timeout;
     bool did_timeout;
     uint16_t timeout_start_ms;
+    uint8_t wire_error;
 
     uint8_t stop_variable; // read by init and used when starting measurement; is StopVariable field of VL53L0X_DevData_t structure in API
     uint32_t measurement_timing_budget_us;
@@ -173,6 +175,12 @@ class VL53L0X
     static uint16_t encodeTimeout(uint32_t timeout_mclks);
     static uint32_t timeoutMclksToMicroseconds(uint16_t timeout_period_mclks, uint8_t vcsel_period_pclks);
     static uint32_t timeoutMicrosecondsToMclks(uint32_t timeout_period_us, uint8_t vcsel_period_pclks);
+
+    inline void setWireErrorBit(void) {
+      if (last_status) {
+        bitSet(wire_error, last_status);
+      }
+    }
 };
 
 #endif


### PR DESCRIPTION
last_status is reasonable solution to get the last status of i2c
trnasmittion, but in some cases, the last_status is overwritten by
calling read/write register API more than once. For instance, init(),
startContinuous(), etc.

Especially on Arduino IDE 1.8.13, new error code `5` (i2c timeout) is
added to Wire.endTransmission() by merging this PR
https://github.com/arduino/ArduinoCore-avr/pull/107 .

You can distinguish what error occurs and use them depending on the
situation.